### PR TITLE
Avoid restarting the game using the Up Arrow key

### DIFF
--- a/play.c
+++ b/play.c
@@ -1250,7 +1250,7 @@ void play_handle_input(int key_code)
         default:
             break;
         }
-    } else if (is_dead && (key_code == ' ' || key_code == 10 ||
-                           key_code == TUI_KEY_UP || key_code == TUI_KEY_ENTER))
+    } else if (is_dead &&
+               (key_code == ' ' || key_code == 10 || key_code == TUI_KEY_ENTER))
         play_init_world();
 }


### PR DESCRIPTION
Currently, when the player is doing a Jump action during the gameover sequence by pressing the Up Arrow key, the game immediately restarts, preventing the player from accessing information provided in the gameover screen.

This patch drops the condition that triggers this behavior.

Fixes #4.